### PR TITLE
fix: setup npm publishing with OIDC and release-please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish Package
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '**/*.test.ts'
+      - '.*'
+      - '.claude/**'
+      - '.vscode/**'
+      - '.github/**'
+      - '!.github/workflows/publish.yml'
+
+permissions:
+  id-token: write  # Required for OIDC authentication
+  contents: read
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Release Please
+        id: release
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          scope: '@lacolaco'
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+      - name: Publish to npm
+        run: npm publish --provenance --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,26 +65,35 @@ This project implements the Agent Communication Language (ACL) specification def
 
 ## Publishing
 
-This package uses **npm Trusted Publishing** with OIDC authentication for secure package publishing without long-lived tokens.
+This package uses **automated releases** with release-please and **npm Trusted Publishing** with OIDC authentication.
 
-### Setup Requirements
+### Publishing Process
 
-1. **npm Configuration** (on npmjs.com):
-   - Navigate to package settings → "Trusted Publisher"
-   - Configure:
-     - Organization: `lacolaco`
-     - Repository: `acl`
-     - Workflow: `.github/workflows/publish.yml`
+1. **Commit with Conventional Commits**:
+   - Use conventional commit format: `feat:`, `fix:`, `docs:`, etc.
+   - Push commits to main branch
 
-2. **Publishing Process**:
-   - Create and push a git tag: `git tag v0.0.1 && git push --tags`
-   - GitHub Actions workflow automatically builds, tests, and publishes
-   - Uses OIDC for authentication (no secrets required)
+2. **Automatic Release PR**:
+   - release-please automatically creates/updates a release PR
+   - The PR includes version bump and CHANGELOG updates
 
-3. **Requirements**:
-   - npm 11.5.1+ (automatically upgraded in workflow)
-   - `id-token: write` permission in workflow
-   - `publishConfig.access: "public"` in package.json
+3. **Publish**:
+   - Merge the release PR
+   - GitHub Actions automatically publishes to npm with provenance
+   - Uses OIDC authentication (no secrets required)
+
+### npm Trusted Publisher Setup
+
+Configure on npmjs.com package settings → "Trusted Publisher":
+- Organization: `lacolaco`
+- Repository: `acl`
+- Workflow: `.github/workflows/publish.yml`
+
+### Technical Requirements
+
+- npm 11.5.1+ (automatically upgraded in workflow)
+- `id-token: write` permission for OIDC
+- `publishConfig.provenance: true` in package.json
 
 ## Key Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,29 @@ Tests use `InMemoryTransport.createLinkedPair()` to create connected client-serv
 
 This project implements the Agent Communication Language (ACL) specification defined in `ACL.md`. The MCP server acts as a bridge between AI agents and ACL commands, enabling structured agent communication.
 
+## Publishing
+
+This package uses **npm Trusted Publishing** with OIDC authentication for secure package publishing without long-lived tokens.
+
+### Setup Requirements
+
+1. **npm Configuration** (on npmjs.com):
+   - Navigate to package settings → "Trusted Publisher"
+   - Configure:
+     - Organization: `lacolaco`
+     - Repository: `acl`
+     - Workflow: `.github/workflows/publish.yml`
+
+2. **Publishing Process**:
+   - Create and push a git tag: `git tag v0.0.1 && git push --tags`
+   - GitHub Actions workflow automatically builds, tests, and publishes
+   - Uses OIDC for authentication (no secrets required)
+
+3. **Requirements**:
+   - npm 11.5.1+ (automatically upgraded in workflow)
+   - `id-token: write` permission in workflow
+   - `publishConfig.access: "public"` in package.json
+
 ## Key Dependencies
 
 - `@modelcontextprotocol/sdk`: Core MCP server/client implementation

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "description": "",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "main": "./dist/main.cjs",
   "module": "./dist/main.mjs",


### PR DESCRIPTION
## Summary

Setup automated npm publishing with OIDC authentication and release-please for version management.

## Changes

- Add GitHub Actions workflow for automated publishing
- Configure npm Trusted Publishing with OIDC authentication  
- Integrate release-please for automatic version management
- Enable provenance generation for package security
- Update documentation with publishing process

## Publishing Workflow

1. Commit with conventional commits format
2. release-please automatically creates/updates release PR
3. Merge release PR to trigger npm publish

## Requirements for npm Setup

Configure Trusted Publisher on npmjs.com:
- Organization: `lacolaco`
- Repository: `acl`
- Workflow: `.github/workflows/publish.yml`