### PR TITLE
fix(ci): remove npm upgrade step to avoid permission errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org'
           scope: '@lacolaco'
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+      - name: Check npm version
+        run: npm -v
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
## Summary

Remove the npm global upgrade step that was causing permission errors in the CI workflow.

## Problem

The workflow was failing with `EACCES: permission denied` when trying to upgrade npm globally:
```
npm error path /usr/local/share/man/man7
npm error errno -13
```

## Solution

- Remove the `npm install -g npm@latest` step
- Use the default npm version provided by ubuntu-latest runner
- The default npm version (10.x) already supports OIDC (requires npm 9.5.0+)

## Changes

- Replace "Upgrade npm for OIDC support" step with "Check npm version"
- Simply display npm version instead of attempting global install

## Testing

This should allow the publish job to proceed without permission errors.