### PR TITLE
feat(ci): add workflow_dispatch for manual publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,17 @@ on:
       - '.vscode/**'
       - '.github/**'
       - '!.github/workflows/publish.yml'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish (tag, branch, or commit SHA)'
+        required: true
+        default: 'main'
+        type: string
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -34,13 +42,15 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required for OIDC authentication
       id-token: write
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '' }}
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:


### PR DESCRIPTION
## Summary

Add manual workflow trigger to enable publishing from any git ref without waiting for release-please.

## Problem

Currently, the publish job only runs when release-please creates a new release. If a release already exists (like v1.0.2), there's no way to republish or manually trigger npm publishing.

## Solution

Add `workflow_dispatch` trigger with the following features:

1. **Manual Trigger**: Run workflow from GitHub Actions UI
2. **Flexible Ref Selection**: Specify any tag, branch, or commit SHA to publish
3. **Independent from release-please**: Can publish without creating a release

## Changes

- Add `workflow_dispatch` trigger with `ref` input parameter
- Make `release-please` job conditional (only runs on `push` events)
- Update `publish` job to run on either:
  - release-please creating a release, OR
  - manual workflow_dispatch trigger
- Checkout specified ref when triggered manually
- Add explicit pnpm version (10.14.0)

## Usage

### Manual Publishing

1. Go to Actions → "Publish Package"
2. Click "Run workflow"
3. Enter the ref to publish (e.g., `v1.0.2`, `main`, or commit SHA)
4. Click "Run workflow"

This allows publishing existing releases or testing publish workflow with specific commits.

## Testing

After merge, we can test by manually triggering the workflow with `v1.0.2` to publish the current release to npm.