### PR TITLE
fix(ci): install npm 11.15.1+ and remove pnpm version duplication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,14 +52,14 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '' }}
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10.14.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           registry-url: 'https://registry.npmjs.org'
           scope: '@lacolaco'
-      - name: Check npm version
-        run: npm -v
+      - name: Install npm 11.15.1+
+        run: |
+          sudo npm install -g npm@latest
+          npm -v
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ This project implements the Agent Communication Language (ACL) specification def
 
 This package uses **automated releases** with release-please and **npm Trusted Publishing** with OIDC authentication.
 
+**Note**: pnpm version is specified in `package.json` (`packageManager` field), so it should not be duplicated in workflow files. The `pnpm/action-setup` action automatically reads this field.
+
 ### Publishing Process
 
 1. **Commit with Conventional Commits**:


### PR DESCRIPTION
## Summary

Install latest npm version for improved OIDC support and remove redundant pnpm version specification from workflow.

## Changes

1. **Install npm 11.15.1+**:
   - Add upgrade step using `sudo npm install -g npm@latest`
   - Ensures latest OIDC and provenance features are available

2. **Remove pnpm version duplication**:
   - Remove `version: 10.14.0` from `pnpm/action-setup`
   - pnpm version is managed by `package.json` (`packageManager` field)
   - The action automatically reads this field

3. **Documentation**:
   - Add note in CLAUDE.md about pnpm version management convention

## Why sudo?

GitHub Actions runners require `sudo` for global npm installation to `/usr/local/` directories. Without it, the install fails with `EACCES` permission errors.

## Testing

After merge, the workflow can be tested using workflow_dispatch to publish v1.0.2.