### PR TITLE
fix: add repository field to package.json for provenance validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   },
   "keywords": [],
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lacolaco/acl.git"
+  },
   "packageManager": "pnpm@10.14.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.19.1"


### PR DESCRIPTION
## Summary

Add `repository` field to package.json to fix provenance validation error during npm publish.

## Problem

Publishing fails with error:
```
npm error 422 - Error verifying sigstore provenance bundle: 
Failed to validate repository information: 
package.json: "repository.url" is "", expected to match "https://github.com/lacolaco/acl"
```

## Solution

Add the required `repository` field to package.json with:
```json
{
  "repository": {
    "type": "git",
    "url": "https://github.com/lacolaco/acl.git"
  }
}
```

## Testing

After merge, npm publish with `--provenance` should succeed.