### PR TITLE
feat: add get_acl_specification tool and modular architecture

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "acl": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "dist/main.js"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "bin": {
     "acl-mcp-server": "./dist/main.js"
   },
+  "type": "module",
   "scripts": {
-    "test": "vitest",
+    "test": "pnpm run typecheck && vitest",
+    "typecheck": "tsc --noEmit",
     "start": "tsx src/main.ts",
     "build": "tsup src/main.ts --format esm,cjs --dts",
     "format": "prettier --cache --write .",
@@ -39,5 +41,10 @@
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
     "zod": "^3.25.76"
+  },
+  "tsup": {
+    "clean": true,
+    "dts": true,
+    "shims": true
   }
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,35 +1,30 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { helloTool } from "./tools/hello.js";
+import { getAclSpecificationTool } from "./tools/get-acl-specification.js";
 
-const server = new McpServer({
-  name: "acl-mcp-server",
-  version: "1.0.0",
-  capabilities: {
-    tools: true,
-  },
-});
+describe("MCP Server Integration", () => {
+  let server: McpServer;
 
-server.registerTool(
-  "hello",
-  {
-    title: "Hello Tool",
-    description: "Says hello",
-    inputSchema: {
-      name: z.string().describe("The name to say hello to"),
-    },
-  },
-  async ({ name }) => {
-    return {
-      content: [{ type: "text", text: `Hello, ${name}!` }],
-    };
-  },
-);
+  beforeEach(() => {
+    server = new McpServer({
+      name: "acl-mcp-server",
+      version: "1.0.0",
+      capabilities: {
+        tools: true,
+      },
+    });
 
-describe("server", () => {
-  it("should say hello", async () => {
+    server.registerTool(helloTool.name, helloTool.config, helloTool.callback);
+    server.registerTool(
+      getAclSpecificationTool.name,
+      getAclSpecificationTool.config,
+      getAclSpecificationTool.callback,
+    );
+  });
+  it("should call hello tool via MCP protocol", async () => {
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
     server.connect(serverTransport);
@@ -47,5 +42,34 @@ describe("server", () => {
       },
     });
     expect(result.content).toEqual([{ type: "text", text: "Hello, world!" }]);
+  });
+
+  it("should call get_acl_specification tool via MCP protocol", async () => {
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    server.connect(serverTransport);
+
+    const client = new McpClient({
+      name: "test-client",
+      version: "1.0.0",
+    });
+    client.connect(clientTransport);
+
+    const result = await client.callTool({
+      name: "get_acl_specification",
+      arguments: {},
+    });
+
+    if (!Array.isArray(result.content)) {
+      throw new Error("Expected content to be an array");
+    }
+
+    expect(result.content).toHaveLength(1);
+    const firstContent = result.content[0];
+    expect(firstContent).toHaveProperty("type", "text");
+    if (firstContent.type === "text") {
+      expect(firstContent.text).toContain("Agent Communication Language (ACL)");
+      expect(firstContent.text).toContain("Language Specification");
+    }
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
+import { helloTool } from "./tools/hello.js";
+import { getAclSpecificationTool } from "./tools/get-acl-specification.js";
 
 const server = new McpServer({
   name: "acl-mcp-server",
@@ -10,20 +11,11 @@ const server = new McpServer({
   },
 });
 
+server.registerTool(helloTool.name, helloTool.config, helloTool.callback);
 server.registerTool(
-  "hello",
-  {
-    title: "Hello Tool",
-    description: "Says hello",
-    inputSchema: {
-      name: z.string().describe("The name to say hello to"),
-    },
-  },
-  async ({ name }) => {
-    return {
-      content: [{ type: "text", text: `Hello, ${name}!` }],
-    };
-  },
+  getAclSpecificationTool.name,
+  getAclSpecificationTool.config,
+  getAclSpecificationTool.callback,
 );
 
 const transport = new StdioServerTransport();

--- a/src/tools/get-acl-specification.test.ts
+++ b/src/tools/get-acl-specification.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getAclSpecificationTool } from "./get-acl-specification.js";
+
+describe("getAclSpecificationTool", () => {
+  it("should have correct tool definition", () => {
+    expect(getAclSpecificationTool.name).toBe("get_acl_specification");
+    expect(getAclSpecificationTool.config.title).toBe("Get ACL Specification");
+    expect(getAclSpecificationTool.config.description).toContain(
+      "Agent Communication Language",
+    );
+    expect(getAclSpecificationTool.config.inputSchema).toEqual({});
+  });
+
+  it("should return ACL specification content", async () => {
+    const result = await getAclSpecificationTool.callback();
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toHaveProperty("type", "text");
+    expect(result.content[0]).toHaveProperty("text");
+
+    if (result.content[0].type === "text") {
+      const text = result.content[0].text;
+      expect(text).toContain("Agent Communication Language (ACL)");
+      expect(text).toContain("Language Specification");
+      expect(text).toContain("## 1. Introduction");
+    }
+  });
+
+  it("should read ACL.md from project root", async () => {
+    const result = await getAclSpecificationTool.callback();
+
+    if (result.content[0].type === "text") {
+      // Verify it contains typical ACL spec sections
+      const text = result.content[0].text;
+      expect(text).toContain("Built-in Objects");
+      expect(text).toContain("agent");
+      expect(text).toContain("project");
+      expect(text).toContain("session");
+    }
+  });
+});

--- a/src/tools/get-acl-specification.ts
+++ b/src/tools/get-acl-specification.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function getDirname() {
+  // tsup shims `import.meta.url` for CJS output, so this works in both CJS and ESM.
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+export const getAclSpecificationTool = {
+  name: "get_acl_specification",
+  config: {
+    title: "Get ACL Specification",
+    description:
+      "Returns the Agent Communication Language (ACL) specification from ACL.md",
+    inputSchema: {},
+  },
+  callback: (async () => {
+    const aclPath = path.join(getDirname(), "..", "..", "ACL.md");
+    const aclContent = await readFile(aclPath, "utf-8");
+    return {
+      content: [{ type: "text", text: aclContent }],
+    };
+  }) satisfies ToolCallback,
+} as const;

--- a/src/tools/hello.test.ts
+++ b/src/tools/hello.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { helloTool } from "./hello.js";
+
+describe("helloTool", () => {
+  it("should have correct tool definition", () => {
+    expect(helloTool.name).toBe("hello");
+    expect(helloTool.config.title).toBe("Hello Tool");
+    expect(helloTool.config.description).toBe("Says hello");
+    expect(helloTool.config.inputSchema).toBeDefined();
+  });
+
+  it("should return greeting message", async () => {
+    const result = await helloTool.callback({ name: "World" });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "Hello, World!",
+    });
+  });
+
+  it("should handle different names", async () => {
+    const result = await helloTool.callback({ name: "Alice" });
+
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "Hello, Alice!",
+    });
+  });
+});

--- a/src/tools/hello.ts
+++ b/src/tools/hello.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const inputSchema = {
+  name: z.string().describe("The name to say hello to"),
+};
+
+export const helloTool = {
+  name: "hello",
+  config: {
+    title: "Hello Tool",
+    description: "Says hello",
+    inputSchema,
+  },
+  callback: (async ({ name }) => {
+    return {
+      content: [{ type: "text", text: `Hello, ${name}!` }],
+    };
+  }) satisfies ToolCallback<typeof inputSchema>,
+} as const;


### PR DESCRIPTION
## Summary

This PR adds a new MCP tool `get_acl_specification` that returns the ACL specification from `ACL.md`, along with a comprehensive refactoring to a modular tool architecture.

### New Feature
- **get_acl_specification tool**: Returns the Agent Communication Language specification document

### Architecture Improvements
- **Modular tool structure**: Tools moved to `src/tools/` directory
  - Each tool is a pure object with `name`, `config`, and `callback`
  - Uses SDK `ToolCallback` type for type safety
  - No barrel exports (index.ts) - direct imports only
  
### Testing Enhancements
- **Unit tests**: Added `hello.test.ts` and `get-acl-specification.test.ts`
- **Integration tests**: Refactored `main.test.ts` with `beforeEach` setup
- **Type checking**: `pnpm test` now runs `tsc --noEmit` before tests
- **Coverage**: 8 tests across 3 files (all passing ✓)

### Build Configuration
- Added `"type": "module"` to package.json for ESM
- Configured tsup with `shims: true` for `import.meta.url` in CJS
- Added `typecheck` script for manual type checking

### Documentation
- Updated CLAUDE.md with:
  - Modular architecture documentation
  - Tool definition pattern examples
  - Build system details
  - Updated ACL method definitions

## Test Plan
- [x] All tests pass (8/8)
- [x] TypeScript type check passes
- [x] Build succeeds for both ESM and CJS

## Breaking Changes
None - all changes are additive or internal refactoring