### PR TITLE
feat: enhance ACL specification with detailed object definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,12 +140,48 @@ Configure on npmjs.com package settings → "Trusted Publisher":
 
 # ACL Method Definitions
 
-project: {
-  test: exec("pnpm test"),
-  typecheck: exec("pnpm run typecheck"),
-  start: exec("pnpm start"),
-  build: exec("pnpm run build"),
-  format: exec("pnpm format"),
-  inspect: exec("pnpm inspect"),
-  inspectDist: exec("pnpm inspect:dist")
+```acl
+obj spec = "ACL spec file; ACL.md"
+
+obj project = "MCP server implementation that provides ACL support"
+
+fn project.test(): void {
+  description: "Run tests using Vitest"
+  action: exec("pnpm test")
 }
+
+fn project.typecheck(): void {
+  description: "Type check using TypeScript"
+  action: exec("pnpm run typecheck")
+}
+
+fn project.start(): void {
+  description: "Start development server using tsx"
+  action: exec("pnpm start")
+}
+
+fn project.build(): void {
+  description: "Build for production (ESM and CJS bundles)"
+  action: exec("pnpm run build")
+}
+
+fn project.format(): void {
+  description: "Format code using Prettier"
+  action: exec("pnpm format")
+}
+
+fn project.inspect(): void {
+  description: "Inspect MCP server in development mode"
+  action: exec("pnpm inspect")
+}
+
+fn project.inspectDist(): void {
+  description: "Inspect built MCP server"
+  action: exec("pnpm inspect:dist")
+}
+
+fn finish(task): void {
+  description: "Complete task with cleanup, tests, commit, and PR"
+  action: tidyUp() && test() && git.commit(task).push() && github.pr(task)
+}
+```

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -69,7 +69,7 @@ describe("MCP Server Integration", () => {
     expect(firstContent).toHaveProperty("type", "text");
     if (firstContent.type === "text") {
       expect(firstContent.text).toContain("Agent Communication Language (ACL)");
-      expect(firstContent.text).toContain("Language Specification");
+      expect(firstContent.text).toContain("## 1. Introduction");
     }
   });
 });

--- a/src/tools/get-acl-specification.test.ts
+++ b/src/tools/get-acl-specification.test.ts
@@ -21,7 +21,6 @@ describe("getAclSpecificationTool", () => {
     if (result.content[0].type === "text") {
       const text = result.content[0].text;
       expect(text).toContain("Agent Communication Language (ACL)");
-      expect(text).toContain("Language Specification");
       expect(text).toContain("## 1. Introduction");
     }
   });
@@ -32,8 +31,8 @@ describe("getAclSpecificationTool", () => {
     if (result.content[0].type === "text") {
       // Verify it contains typical ACL spec sections
       const text = result.content[0].text;
-      expect(text).toContain("Built-in Objects");
-      expect(text).toContain("agent");
+      expect(text).toContain("## 4. Objects");
+      expect(text).toContain("ACL");
       expect(text).toContain("project");
       expect(text).toContain("session");
     }


### PR DESCRIPTION
## Summary

This PR enhances the ACL specification with more detailed and structured object definitions using the ACL syntax itself.

### Key Changes

- **Removed `ACL.def()` and `ACL.undef()` methods**: Simplified the API by removing these methods in favor of direct `obj` and `fn` syntax in CLAUDE.md
- **Added `ACL.load()` method**: New method to explicitly load project's ACL definitions into working context
- **Detailed object definitions**: Redefined `ACL`, `project`, and `session` objects using comprehensive ACL syntax with multi-step action arrays
- **Added `exec()` as built-in global function**: Formalized shell command execution as a core ACL function
- **Updated all examples**: Migrated all examples from `ACL.def()` syntax to `obj`/`fn` keywords
- **Fixed test assertions**: Updated tests to match the new spec structure

### Breaking Changes

- `ACL.def()` and `ACL.undef()` are no longer available
- Users should define objects and functions directly using `obj` and `fn` keywords in CLAUDE.md

### Migration Guide

**Before:**
```acl
ACL.def(apiData, fetch("https://api.example.com/metrics"))
ACL.undef(project.deploy, project.publish)
```

**After:**
```acl
obj apiData = fetch("https://api.example.com/metrics")
# Remove method definitions directly from CLAUDE.md
```

## Test Plan

- [x] All existing tests pass
- [x] Test assertions updated to match new spec structure
- [x] Type checking passes