### PR TITLE
fix: update package.json bin to single executable format and improve begin() workflow

### DIFF
--- a/ACL.md
+++ b/ACL.md
@@ -119,15 +119,6 @@ Global functions work across all projects and are called without a scope prefix.
 ### Built-in Function Definitions
 
 ```acl
-fn begin(goal): void {
-  description: "Begin working on task with git branch and TODO planning"
-  action: [
-    "Create dedicated git branch for the task",
-    "Draft initial TODO list based on goal",
-    "Request user agreement on approach"
-  ]
-}
-
 fn fix(issue): void {
   description: "Analyze and fix problems"
   action: [
@@ -200,11 +191,6 @@ fn exec(command): number {
 ### Usage
 
 ```acl
-# Begin a task
-begin("implement user authentication")
-begin("add pagination to API")
-begin("refactor database layer")
-
 # Fix issues
 fix("typescript errors")
 fix("failing unit tests")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,8 +210,11 @@ fn project.inspectDist(): void {
 }
 
 fn begin(goal): task {
-  description: "Begin working on task with git branch and TODO planning; pairs with finish(task)"
+  description: "Begin working on task with git branch and TODO planning; ALWAYS starts from up-to-date origin/main; pairs with finish(task)"
   action: [
+    "Switch to main branch with git checkout main",
+    "Fetch latest changes with git fetch origin",
+    "Update local main with git pull origin main",
     "Create dedicated git branch for the task",
     "Draft initial TODO list based on goal",
     "Request user agreement on approach"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "dist",
     "ACL.md"
   ],
-  "bin": {
-    "acl-mcp-server": "./dist/main.js"
-  },
+  "bin": "./dist/main.js",
   "type": "module",
   "scripts": {
     "test": "pnpm run typecheck && vitest",


### PR DESCRIPTION
## Summary

This PR fixes the package.json bin field format and improves the project-local `begin()` workflow to prevent issues with stale branches.

### Key Changes

1. **Fix package.json bin Field Format**
   - Changed from object format: `{"acl-mcp-server": "./dist/main.js"}`
   - To single executable string: `"./dist/main.js"`
   - **Impact**: Executable name will change from `acl-mcp-server` to `acl` (derived from package name `@lacolaco/acl`)
   - Follows npm standard for single-executable packages

2. **Improve begin() Workflow in CLAUDE.md**
   - Added mandatory steps to ensure starting from up-to-date origin/main:
     - `git checkout main` - Switch to main branch
     - `git fetch origin` - Fetch latest changes
     - `git pull origin main` - Update local main
   - Updated description to emphasize "ALWAYS starts from up-to-date origin/main"
   - Prevents creating branches from stale local state
   - Reduces merge conflicts and ensures clean starting point

3. **Clean up ACL.md**
   - Removed `begin()` from built-in global functions section
   - `begin()` is now defined as a project-local function in CLAUDE.md
   - Maintains correct separation between built-in globals (ACL.md) and project-specific functions (CLAUDE.md)

### Rationale

This change was triggered by an alert during task execution where the agent attempted to create a new branch without first updating from origin/main, violating the intended workflow specification.

## Test Plan

- [x] All existing tests pass (6 tests across 3 test files)
- [x] Type checking passes
- [x] Build succeeds
- [x] Verified package.json bin field syntax
- [x] Confirmed CLAUDE.md begin() includes fetch/pull steps
- [x] Confirmed ACL.md no longer contains begin() in built-ins

### Test Results
```
✓ src/tools/get-acl-specification.test.ts (3 tests)
✓ src/main.test.ts (1 test)
✓ src/resources/acl-instructions.test.ts (2 tests)

Test Files  3 passed (3)
Tests  6 passed (6)
```

## Impact

### Breaking Change
- **Executable name changes from `acl-mcp-server` to `acl`**
- Users installing globally will need to update their command usage
- MCP configuration files referencing the executable will need updates

### Improvements
- More reliable workflow starting from clean, up-to-date state
- Reduced risk of merge conflicts
- Better adherence to ACL specifications
- Clearer separation of built-in vs project-local functions