### PR TITLE
fix: add executable hashbang and extract server factory

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,64 +1,7 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+#!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { getAclSpecificationTool } from "./tools/get-acl-specification.js";
-import { registerInstructionsResource } from "./resources/acl-instructions.js";
+import { createMcpServer } from "./mcp-server.js";
 
-const server = new McpServer({
-  name: "acl-mcp-server",
-  version: "1.0.0",
-  capabilities: {
-    tools: true,
-    resources: true,
-  },
-  instructions: `
-<General Purpose>
-This server provides tools and resources for working with Agent Communication Language (ACL), a Domain-Specific Language for concise, structured communication with AI agents in development workflows.
-
-Your primary goal is to help users understand, write, and execute ACL commands for workflow automation, knowledge management, and agent customization.
-</General Purpose>
-
-<Core Workflows & Tool Guide>
-Understanding ACL:
-1. **ALWAYS** start by reading the \`instructions://acl-specification\` resource to understand ACL syntax and semantics
-2. Use \`get_acl_specification\` tool when you need to reference specific ACL features during execution
-
-Working with ACL Commands:
-* When users write ACL expressions like \`begin()\`, \`finish()\`, \`ACL.init()\`, \`ACL.load()\`, reference the specification
-* ACL follows \`scope.action(details)\` pattern: e.g., \`project.build()\`, \`spec.add()\`, \`session.summary()\`
-* Support chaining operators: \`&&\` (sequential), \`>\` (output redirection), \`.then/.catch/.finally\` (promise-like)
-
-Important Notes:
-* The ACL specification (\`instructions://acl-specification\`) is the authoritative source for all ACL semantics
-* **MUST** consult the specification when interpreting ACL commands to ensure correct behavior
-</Core Workflows & Tool Guide>
-
-<Key Concepts>
-ACL Objects:
-* \`ACL\`: System management (init, load, scan, list)
-* \`project\`: Current project context with build/test/deploy methods
-* \`session\`: Current conversation (summary, insights)
-* \`spec\`: ACL specification file (add, remove methods)
-
-Global Functions:
-* \`begin\`, \`finish\`: Task lifecycle management
-* \`fix\`, \`refactor\`, \`test\`: Code quality operations
-* \`note\`, \`docs\`: Knowledge management
-* \`alert\`, \`retry\`: Error handling
-
-Declaration Syntax:
-* \`obj objectName = "description"\`: Declare an object
-* \`fn functionName(params): returnType { ... }\`: Define a function
-* CLAUDE.md: Project-specific ACL method definitions stored in \`acl\` codeblock under "# ACL Method Definitions" section
-</Key Concepts>`,
-});
-
-server.registerTool(
-  getAclSpecificationTool.name,
-  getAclSpecificationTool.config,
-  getAclSpecificationTool.callback,
-);
-
-registerInstructionsResource(server);
-
+const server = createMcpServer();
 const transport = new StdioServerTransport();
 server.connect(transport);

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -2,26 +2,15 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, it, expect, beforeEach } from "vitest";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
-import { getAclSpecificationTool } from "./tools/get-acl-specification.js";
+import { createMcpServer } from "./mcp-server.js";
 
 describe("MCP Server Integration", () => {
   let server: McpServer;
 
   beforeEach(() => {
-    server = new McpServer({
-      name: "acl-mcp-server",
-      version: "1.0.0",
-      capabilities: {
-        tools: true,
-      },
-    });
-
-    server.registerTool(
-      getAclSpecificationTool.name,
-      getAclSpecificationTool.config,
-      getAclSpecificationTool.callback,
-    );
+    server = createMcpServer();
   });
+
   it("should call get_acl_specification tool via MCP protocol", async () => {
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,64 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getAclSpecificationTool } from "./tools/get-acl-specification.js";
+import { registerInstructionsResource } from "./resources/acl-instructions.js";
+
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "acl-mcp-server",
+    version: "1.0.0",
+    capabilities: {
+      tools: true,
+      resources: true,
+    },
+    instructions: `
+<General Purpose>
+This server provides tools and resources for working with Agent Communication Language (ACL), a Domain-Specific Language for concise, structured communication with AI agents in development workflows.
+
+Your primary goal is to help users understand, write, and execute ACL commands for workflow automation, knowledge management, and agent customization.
+</General Purpose>
+
+<Core Workflows & Tool Guide>
+Understanding ACL:
+1. **ALWAYS** start by reading the \`instructions://acl-specification\` resource to understand ACL syntax and semantics
+2. Use \`get_acl_specification\` tool when you need to reference specific ACL features during execution
+
+Working with ACL Commands:
+* When users write ACL expressions like \`begin()\`, \`finish()\`, \`ACL.init()\`, \`ACL.load()\`, reference the specification
+* ACL follows \`scope.action(details)\` pattern: e.g., \`project.build()\`, \`spec.add()\`, \`session.summary()\`
+* Support chaining operators: \`&&\` (sequential), \`>\` (output redirection), \`.then/.catch/.finally\` (promise-like)
+
+Important Notes:
+* The ACL specification (\`instructions://acl-specification\`) is the authoritative source for all ACL semantics
+* **MUST** consult the specification when interpreting ACL commands to ensure correct behavior
+</Core Workflows & Tool Guide>
+
+<Key Concepts>
+ACL Objects:
+* \`ACL\`: System management (init, load, scan, list)
+* \`project\`: Current project context with build/test/deploy methods
+* \`session\`: Current conversation (summary, insights)
+* \`spec\`: ACL specification file (add, remove methods)
+
+Global Functions:
+* \`begin\`, \`finish\`: Task lifecycle management
+* \`fix\`, \`refactor\`, \`test\`: Code quality operations
+* \`note\`, \`docs\`: Knowledge management
+* \`alert\`, \`retry\`: Error handling
+
+Declaration Syntax:
+* \`obj objectName = "description"\`: Declare an object
+* \`fn functionName(params): returnType { ... }\`: Define a function
+* CLAUDE.md: Project-specific ACL method definitions stored in \`acl\` codeblock under "# ACL Method Definitions" section
+</Key Concepts>`,
+  });
+
+  server.registerTool(
+    getAclSpecificationTool.name,
+    getAclSpecificationTool.config,
+    getAclSpecificationTool.callback,
+  );
+
+  registerInstructionsResource(server);
+
+  return server;
+}


### PR DESCRIPTION
## Summary
- Added `#!/usr/bin/env node` hashbang to `src/main.ts` to make the built file directly executable
- Extracted MCP server creation logic from `main.ts` to `src/mcp-server.ts`
- Created `createMcpServer()` factory function for improved testability and reusability
- Renamed `main.test.ts` to `mcp-server.test.ts` to better reflect what it's testing
- Updated tests to use the new factory function

## Test plan
- [x] All existing tests pass (pnpm test)
- [x] TypeScript compilation succeeds
- [x] Verified hashbang is preserved in build output (dist/main.js)
- [x] Tests properly use createMcpServer() factory