### PR TITLE
fix: improve ACL.md path resolution and add caching

### DIFF
--- a/ACL.md
+++ b/ACL.md
@@ -138,8 +138,16 @@ fn refactor(targets, direction): void {
 }
 
 fn think(issue): string {
-  description: "Analyze without modifying files"
-  action: "Read-only analysis, provide insights and recommendations without making any changes"
+  description: "Analyze issue with read-only operations; strictly forbidden to modify any files or execute commands"
+  action: [
+    "Use ONLY read-only tools (Read, Grep, Glob, WebFetch) to investigate",
+    "Analyze the problem and provide detailed insights",
+    "Present recommendations and potential solutions to user",
+    "FORBIDDEN: Edit, Write, NotebookEdit, Bash, or any state-modifying operations",
+    "FORBIDDEN: Making any changes to files, executing commands, or taking corrective actions",
+    "REQUIRED: Wait for explicit user instruction (fix, refactor, begin, etc.) before any action"
+  ]
+  returns: "Analysis, insights, and recommendations as text output only"
 }
 
 fn test(pattern?): object {
@@ -198,7 +206,7 @@ fix("failing unit tests")
 # Safe refactoring
 refactor("auth module", "separate concerns")
 
-# Analysis only (no changes)
+# Read-only analysis (strictly no file modifications or command execution)
 think("optimal caching strategy")
 
 # Run tests

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "packageManager": "pnpm@10.18.1",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.19.1"
+    "@modelcontextprotocol/sdk": "^1.19.1",
+    "find-up": "^8.0.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "0.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.19.1
         version: 1.19.1
+      find-up:
+        specifier: ^8.0.0
+        version: 8.0.0
     devDependencies:
       '@modelcontextprotocol/inspector':
         specifier: 0.17.0
@@ -1128,6 +1131,10 @@ packages:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
 
+  find-up@8.0.0:
+    resolution: {integrity: sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==}
+    engines: {node: '>=20'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -1264,6 +1271,10 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  locate-path@8.0.0:
+    resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
+    engines: {node: '>=20'}
+
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
@@ -1372,6 +1383,14 @@ packages:
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
+
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1775,6 +1794,10 @@ packages:
   undici-types@7.14.0:
     resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -1944,6 +1967,10 @@ packages:
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
@@ -2950,6 +2977,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-up@8.0.0:
+    dependencies:
+      locate-path: 8.0.0
+      unicorn-magic: 0.3.0
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.19
@@ -3075,6 +3107,10 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  locate-path@8.0.0:
+    dependencies:
+      p-locate: 6.0.0
+
   lodash.sortby@4.7.0: {}
 
   loose-envify@1.4.0:
@@ -3168,6 +3204,14 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.1
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
 
   package-json-from-dist@1.0.1: {}
 
@@ -3583,6 +3627,8 @@ snapshots:
 
   undici-types@7.14.0: {}
 
+  unicorn-magic@0.3.0: {}
+
   unpipe@1.0.0: {}
 
   uri-js@4.4.1:
@@ -3733,6 +3779,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yn@3.1.1: {}
+
+  yocto-queue@1.2.1: {}
 
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:

--- a/src/resources/acl-instructions.ts
+++ b/src/resources/acl-instructions.ts
@@ -1,12 +1,5 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-
-function getDirname() {
-  // tsup shims `import.meta.url` for CJS output, so this works in both CJS and ESM.
-  return path.dirname(fileURLToPath(import.meta.url));
-}
+import { getAclSpecification } from "../utils/acl-path.js";
 
 export function registerInstructionsResource(server: McpServer): void {
   server.registerResource(
@@ -19,8 +12,7 @@ export function registerInstructionsResource(server: McpServer): void {
       mimeType: "text/markdown",
     },
     async () => {
-      const aclPath = path.join(getDirname(), "..", "..", "ACL.md");
-      const text = await readFile(aclPath, "utf-8");
+      const text = await getAclSpecification();
       return {
         contents: [
           {

--- a/src/tools/get-acl-specification.ts
+++ b/src/tools/get-acl-specification.ts
@@ -1,12 +1,5 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-
-function getDirname() {
-  // tsup shims `import.meta.url` for CJS output, so this works in both CJS and ESM.
-  return path.dirname(fileURLToPath(import.meta.url));
-}
+import { getAclSpecification } from "../utils/acl-path.js";
 
 export const getAclSpecificationTool = {
   name: "get_acl_specification",
@@ -34,8 +27,7 @@ Get the complete Agent Communication Language (ACL) specification document. ACL 
     inputSchema: {},
   },
   callback: (async () => {
-    const aclPath = path.join(getDirname(), "..", "..", "ACL.md");
-    const aclContent = await readFile(aclPath, "utf-8");
+    const aclContent = await getAclSpecification();
     return {
       content: [{ type: "text", text: aclContent }],
     };

--- a/src/utils/acl-path.ts
+++ b/src/utils/acl-path.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import { findUp } from "find-up";
+
+let cachedAclSpecification: string | null = null;
+
+export async function getAclSpecification(): Promise<string> {
+  if (cachedAclSpecification !== null) {
+    return cachedAclSpecification;
+  }
+
+  const aclPath = await findUp("ACL.md");
+
+  if (!aclPath) {
+    throw new Error("ACL.md not found in directory tree");
+  }
+
+  cachedAclSpecification = await readFile(aclPath, "utf-8");
+  return cachedAclSpecification;
+}


### PR DESCRIPTION
## Summary
- Stricten `think()` function definition in ACL.md to explicitly forbid file modifications and command execution
- Add `find-up` dependency to reliably locate ACL.md in both development and production environments
- Create shared utility `src/utils/acl-path.ts` with in-memory caching for improved performance
- Refactor tools and resources to use the shared utility, eliminating code duplication

## Problem
The original implementation used relative paths (`../../ACL.md`) that worked in development but failed in production npm packages due to different directory structures:
- Development: `src/tools/` → `../../ACL.md`
- Production: `dist/` → `../ACL.md`

Additionally, the `think()` function definition was too vague, leading to violations where files were modified during read-only analysis.

## Solution
1. **Stricten think() definition**: Added explicit FORBIDDEN constraints and REQUIRED behavior to prevent file modifications
2. **Use find-up**: Traverse directory tree to locate ACL.md regardless of environment
3. **Add caching**: Cache loaded specification to avoid repeated file I/O
4. **Extract utility**: Centralize ACL loading logic in `src/utils/acl-path.ts`

## Test plan
- [x] All tests pass (`pnpm test`)
- [x] TypeScript compilation succeeds
- [x] Production build succeeds (`pnpm build`)
- [x] ACL.md is correctly loaded in both development and built environments
- [x] Caching works correctly (subsequent calls return cached content)