### PR TITLE
fix: add cwd option to findUp for correct ACL.md resolution in npx environment

### DIFF
--- a/src/utils/acl-path.ts
+++ b/src/utils/acl-path.ts
@@ -1,14 +1,21 @@
 import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { findUp } from "find-up";
 
 let cachedAclSpecification: string | null = null;
+
+function getDirname() {
+  // tsup shims `import.meta.url` for CJS output, so this works in both CJS and ESM.
+  return path.dirname(fileURLToPath(import.meta.url));
+}
 
 export async function getAclSpecification(): Promise<string> {
   if (cachedAclSpecification !== null) {
     return cachedAclSpecification;
   }
 
-  const aclPath = await findUp("ACL.md");
+  const aclPath = await findUp("ACL.md", { cwd: getDirname() });
 
   if (!aclPath) {
     throw new Error("ACL.md not found in directory tree");


### PR DESCRIPTION
## Summary
Fixed ACL.md loading failure when the package is run via `npx` by adding the `cwd` option to `findUp()` in `src/utils/acl-path.ts`.

## Problem
When users ran the package via `npx @lacolaco/acl`, the MCP server failed to load ACL.md with the error:
```
Error: ACL.md not found in directory tree
```

This worked fine in development and local builds but failed in npx environments.

## Root Cause Analysis
The issue was in `src/utils/acl-path.ts`:

**Before (❌ Failed in npx):**
```typescript
const aclPath = await findUp("ACL.md");  // No cwd option
```

Without the `cwd` option, `findUp()` defaults to `process.cwd()`, which is:
- **Development/Local**: Project root directory → ✅ ACL.md found
- **npx execution**: User's current working directory → ❌ ACL.md not in tree

**After (✅ Works everywhere):**
```typescript
const aclPath = await findUp("ACL.md", { cwd: getDirname() });
```

With `{ cwd: getDirname() }`, `findUp()` starts from the directory where the code is executed:
- **Development**: `src/utils/` → searches up to project root → ✅ ACL.md found
- **Production**: `dist/` → searches up to package root → ✅ ACL.md found
- **npx**: `~/.npm/_npx/.../node_modules/@lacolaco/acl/dist/` → searches up to package root → ✅ ACL.md found

## Changes
- Added `getDirname()` helper function to get the current module's directory
- Added `{ cwd: getDirname() }` option to `findUp()` call
- Added necessary imports (`path`, `fileURLToPath`)

## Testing

### Before Fix
```bash
$ npx -y @lacolaco/acl@1.3.2-debug.1 --debug
❌ Failed to load ACL.md:
  Error: ACL.md not found in directory tree
```

### After Fix
```bash
$ npx -y @lacolaco/acl@1.3.2-debug.2 --debug
✅ ACL.md found and loaded
  Content length: 25100 characters
```

## Test Plan
- [x] All unit tests pass (`pnpm test`)
- [x] TypeScript compilation succeeds
- [x] Development mode works (`pnpm start`)
- [x] Local build works (`node dist/main.js`)
- [x] npx execution works (verified with beta version `1.3.2-debug.2`)